### PR TITLE
Post repo rename search & replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2024-05-03
+## [0.1.0] - 2024-05-01
 
 ### Added
 
 - First release!
 
-[1.0.0]: https://github.com/infrastructure-blocks/rust-binary-template/releases/tag/v0.1.0
+[0.1.0]: https://github.com/infrastructure-blocks/rust-library-template/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "rust-binary-template"
+name = "rust-library-template"
 version = "0.0.0"
 dependencies = [
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust-binary-template"
+name = "rust-library-template"
 version = "0.0.0"
 edition = "2021"
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+build:
+	cargo build
+
 lint:
 	cargo fmt -- --check && cargo clippy --all-targets --all-features -- -D warnings
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
-# rust-binary-template
+# rust-library-template
+[![Build](https://github.com/infrastructure-blocks/rust-library-template/actions/workflows/build.yml/badge.svg)](https://github.com/infrastructure-blocks/rust-library-template/actions/workflows/build.yml)
+[![Release](https://github.com/infrastructure-blocks/rust-library-template/actions/workflows/release.yml/badge.svg)](https://github.com/infrastructure-blocks/rust-library-template/actions/workflows/release.yml)
+[![Trigger Update From Template](https://github.com/infrastructure-blocks/rust-library-template/actions/workflows/trigger-update-from-template.yml/badge.svg)](https://github.com/infrastructure-blocks/rust-library-template/actions/workflows/trigger-update-from-template.yml)
+[![codecov](https://codecov.io/gh/infrastructure-blocks/rust-library-template/graph/badge.svg?token=JHZTAJ66FL)](https://codecov.io/gh/infrastructure-blocks/rust-library-template)
 
-[![Build](https://github.com/infrastructure-blocks/rust-binary-template/actions/workflows/build.yml/badge.svg)](https://github.com/infrastructure-blocks/rust-binary-template/actions/workflows/build.yml)
-[![Release](https://github.com/infrastructure-blocks/rust-binary-template/actions/workflows/release.yml/badge.svg)](https://github.com/infrastructure-blocks/rust-binary-template/actions/workflows/release.yml)
-[![Trigger Update From Template](https://github.com/infrastructure-blocks/rust-binary-template/actions/workflows/trigger-update-from-template.yml/badge.svg)](https://github.com/infrastructure-blocks/rust-binary-template/actions/workflows/trigger-update-from-template.yml)
-[![codecov](https://codecov.io/gh/infrastructure-blocks/rust-binary-template/graph/badge.svg?token=JHZTAJ66FL)](https://codecov.io/gh/infrastructure-blocks/rust-binary-template)
+[//]: # ([![Update From Template]&#40;https://github.com/infrastructure-blocks/rust-library-template/actions/workflows/update-from-template.yml/badge.svg&#41;]&#40;https://github.com/infrastructure-blocks/rust-library-template/actions/workflows/update-from-template.yml&#41;)
 
-Template repository for rust binaries. Upon instantiating, go through the following checklist:
+Template repository for rust libraries. Upon instantiating, go through the following checklist:
 
-- Update [package name](./Cargo.toml)
+- Do a global search & replace for `rust-library-template` and replace it with the name of your repository
 - `cargo build`
-- Update the status badges:
-    - Remove the `Trigger Update From Template` status badge.
-    - Add the `Update From Template` status badge.
-    - Rename the rest of the links to point to the right repository.
-- Replace/rename the relevant sections in this README
+- Remove the [trigger update from template workflow](.github/workflows/trigger-update-from-template.yml)
+- Replace the `Trigger Update From Template` status badge for the `Update From Template` status badge.
+- Describe the package and its usage in this readme.
 - Prepare the [changelog](CHANGELOG.md) for the first version of the module that will be released.
 - Set up code coverage, overwrite the codecov badge with the specific link for your repository.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use clap::{Arg, ArgAction, Command};
-use rust_binary_template::{do_stuff, Config};
+use rust_library_template::{do_stuff, Config};
 
 fn main() {
-    let command = Command::new("rust-binary-template")
+    let command = Command::new("rust-library-template")
         .author("Phil Lavoie")
         .about("This program doesn't do shit.")
         .arg(


### PR DESCRIPTION
- The repo was renamed from rust-binary-template to rust-library-template
